### PR TITLE
Fix issue for Gregorian Calendar

### DIFF
--- a/lib/adtech/api/report.rb
+++ b/lib/adtech/api/report.rb
@@ -105,7 +105,7 @@ module ADTech
         cal.set(Calendar::DAY_OF_MONTH, day)
 		    cal.set(Calendar::MONTH, month)
 		    cal.set(Calendar::YEAR, year)
-		    cal.set(Calendar::HOUR, hour)
+		    cal.set(Calendar::HOUR_OF_DAY, hour)
 		    cal.set(Calendar::MINUTE, minute)
 		    cal.set(Calendar::SECOND, second)
         cal

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -145,4 +145,20 @@ describe ADTech::API::Report do
       end
     end
   end
+
+  describe '.gregorian_calendar' do
+    context 'when given time is end of day' do
+      it 'should return relevant gregorian_calendar object' do
+        cal = @report.send(:gregorian_calendar, 2016, 5, 12, 23, 59, 59)
+        expect(cal.getTime.to_s). to eq('Sun Jun 12 23:59:59 BST 2016')
+      end
+    end
+
+    context 'when given time is beginnig of day' do
+      it 'should return relevant gregorian_calendar object' do
+        cal = @report.send(:gregorian_calendar, 2016, 5, 12, 0, 0, 0)
+        expect(cal.getTime.to_s). to eq('Sun Jun 12 00:00:00 BST 2016')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix issue for Gregorian Calendar
-

Use `HOUR_OF_DAY` for 24h format

Reference
- http://docs.oracle.com/javase/7/docs/api/java/util/Calendar.html#HOUR